### PR TITLE
fix health check failure detection

### DIFF
--- a/endpoint/healthz/endpoint.go
+++ b/endpoint/healthz/endpoint.go
@@ -73,11 +73,11 @@ func (e *Endpoint) Encoder() kithttp.EncodeResponseFunc {
 	return func(ctx context.Context, w http.ResponseWriter, response interface{}) error {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 
-		rs, ok := response.(healthz.Responses)
+		rs, ok := response.([]healthz.Response)
 		if !ok {
-			return microerror.Maskf(wrongTypeError, "expected '%T' got '%T'", healthz.Responses{}, response)
+			return microerror.Maskf(wrongTypeError, "expected '%T' got '%T'", []healthz.Response{}, response)
 		}
-		if rs.HasFailed() {
+		if healthz.Responses(rs).HasFailed() {
 			w.WriteHeader(http.StatusInternalServerError)
 		}
 

--- a/endpoint/healthz/endpoint_test.go
+++ b/endpoint/healthz/endpoint_test.go
@@ -75,7 +75,6 @@ func (s *testService) GetHealthz(ctx context.Context) (healthz.Response, error) 
 }
 
 type testWriter struct {
-	// Settings.
 	statusCode int
 }
 

--- a/endpoint/healthz/endpoint_test.go
+++ b/endpoint/healthz/endpoint_test.go
@@ -3,6 +3,7 @@ package healthz
 import (
 	"context"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/giantswarm/micrologger/microloggertest"
@@ -19,7 +20,7 @@ func Test_Endpoint_ServiceFailed_True(t *testing.T) {
 	}{
 		{
 			Failed:             false,
-			ExpectedStatusCode: 0,
+			ExpectedStatusCode: http.StatusOK,
 		},
 		{
 			Failed:             true,
@@ -49,15 +50,16 @@ func Test_Endpoint_ServiceFailed_True(t *testing.T) {
 			t.Fatalf("test", i+1, "expected", nil, "got", err)
 		}
 
-		w := &testWriter{}
+		w := httptest.NewRecorder()
 
 		err = encoder(context.TODO(), w, res)
 		if err != nil {
 			t.Fatalf("test", i+1, "expected", nil, "got", err)
 		}
 
-		if w.StatusCode() != tc.ExpectedStatusCode {
-			t.Fatalf("test", i+1, "expected", tc.ExpectedStatusCode, "got", w.StatusCode())
+		statusCode := w.Result().StatusCode
+		if statusCode != tc.ExpectedStatusCode {
+			t.Fatalf("test", i+1, "expected", tc.ExpectedStatusCode, "got", statusCode)
 		}
 	}
 }
@@ -72,24 +74,4 @@ func (s *testService) GetHealthz(ctx context.Context) (healthz.Response, error) 
 	}
 
 	return response, nil
-}
-
-type testWriter struct {
-	statusCode int
-}
-
-func (rw *testWriter) Header() http.Header {
-	return http.Header{}
-}
-
-func (rw *testWriter) StatusCode() int {
-	return rw.statusCode
-}
-
-func (rw *testWriter) Write(b []byte) (int, error) {
-	return 0, nil
-}
-
-func (rw *testWriter) WriteHeader(c int) {
-	rw.statusCode = c
 }

--- a/endpoint/healthz/endpoint_test.go
+++ b/endpoint/healthz/endpoint_test.go
@@ -1,0 +1,96 @@
+package healthz
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/giantswarm/micrologger/microloggertest"
+	kitendpoint "github.com/go-kit/kit/endpoint"
+	kithttp "github.com/go-kit/kit/transport/http"
+
+	"github.com/giantswarm/microendpoint/service/healthz"
+)
+
+func Test_Endpoint_ServiceFailed_True(t *testing.T) {
+	testCases := []struct {
+		Failed             bool
+		ExpectedStatusCode int
+	}{
+		{
+			Failed:             false,
+			ExpectedStatusCode: 0,
+		},
+		{
+			Failed:             true,
+			ExpectedStatusCode: http.StatusInternalServerError,
+		},
+	}
+
+	for i, tc := range testCases {
+		var encoder kithttp.EncodeResponseFunc
+		var endpoint kitendpoint.Endpoint
+		{
+			endpointConfig := DefaultConfig()
+			endpointConfig.Logger = microloggertest.New()
+			endpointConfig.Services = []healthz.Service{
+				&testService{Failed: tc.Failed},
+			}
+			newEndpoint, err := New(endpointConfig)
+			if err != nil {
+				t.Fatalf("test", i+1, "expected", nil, "got", err)
+			}
+			encoder = newEndpoint.Encoder()
+			endpoint = newEndpoint.Endpoint()
+		}
+
+		res, err := endpoint(context.TODO(), nil)
+		if err != nil {
+			t.Fatalf("test", i+1, "expected", nil, "got", err)
+		}
+
+		w := &testWriter{}
+
+		err = encoder(context.TODO(), w, res)
+		if err != nil {
+			t.Fatalf("test", i+1, "expected", nil, "got", err)
+		}
+
+		if w.StatusCode() != tc.ExpectedStatusCode {
+			t.Fatalf("test", i+1, "expected", tc.ExpectedStatusCode, "got", w.StatusCode())
+		}
+	}
+}
+
+type testService struct {
+	Failed bool
+}
+
+func (s *testService) GetHealthz(ctx context.Context) (healthz.Response, error) {
+	response := healthz.Response{
+		Failed: s.Failed,
+	}
+
+	return response, nil
+}
+
+type testWriter struct {
+	// Settings.
+	statusCode int
+}
+
+func (rw *testWriter) Header() http.Header {
+	return http.Header{}
+}
+
+func (rw *testWriter) StatusCode() int {
+	return rw.statusCode
+}
+
+func (rw *testWriter) Write(b []byte) (int, error) {
+	return 0, nil
+}
+
+func (rw *testWriter) WriteHeader(c int) {
+	rw.statusCode = c
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 91f8348218ab1365290e92bd64ec095d942f0fe72594a4cbc8189a0dbadec27f
-updated: 2017-08-04T15:08:09.615121337+02:00
+updated: 2017-08-07T14:50:19.180140178+02:00
 imports:
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
@@ -22,7 +22,9 @@ imports:
 - name: github.com/giantswarm/microerror
   version: 5ade94eb4ee35ef72eb9382228470caeddb29989
 - name: github.com/giantswarm/micrologger
-  version: 3fc80a5b178fd25a757c8bbe54599b21b11a1110
+  version: 8a69b2ab80ba2d0bd40d609206518fefacfc8fdf
+  subpackages:
+  - microloggertest
 - name: github.com/go-kit/kit
   version: a9ca6725cbbea455e61c6bc8a1ed28e81eb3493b
   subpackages:

--- a/vendor/github.com/giantswarm/micrologger/logger.go
+++ b/vendor/github.com/giantswarm/micrologger/logger.go
@@ -4,7 +4,7 @@ package micrologger
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"time"
 
 	kitlog "github.com/go-kit/kit/log"
@@ -30,7 +30,7 @@ func DefaultConfig() Config {
 		Caller: func() interface{} {
 			return fmt.Sprintf("%+v", stack.Caller(4))
 		},
-		IOWriter: ioutil.Discard,
+		IOWriter: os.Stdout,
 		TimestampFormatter: func() interface{} {
 			return time.Now().UTC().Format("06-01-02 15:04:05.000")
 		},

--- a/vendor/github.com/giantswarm/micrologger/microloggertest/logger.go
+++ b/vendor/github.com/giantswarm/micrologger/microloggertest/logger.go
@@ -1,0 +1,22 @@
+package microloggertest
+
+import (
+	"io/ioutil"
+
+	"github.com/giantswarm/micrologger"
+)
+
+// New returns a Logger intance configured to discard its output.
+func New() micrologger.Logger {
+	c := micrologger.DefaultConfig()
+	{
+		c.IOWriter = ioutil.Discard
+	}
+
+	logger, err := micrologger.New(c)
+	if err != nil {
+		panic(err)
+	}
+
+	return logger
+}

--- a/vendor/github.com/giantswarm/micrologger/microloggertest/logger_test.go
+++ b/vendor/github.com/giantswarm/micrologger/microloggertest/logger_test.go
@@ -1,0 +1,8 @@
+package microloggertest
+
+import "testing"
+
+func TestNew(t *testing.T) {
+	// Test if New doesn't panic.
+	New()
+}


### PR DESCRIPTION
This PR fixes the following error. 

```
{"caller":"github.com/giantswarm/cert-operator/vendor/github.com/giantswarm/microkit/server/server.go:389","error":"expected 'healthz.Responses' got '[]healthz.Response': wrong type","time":"17-08-07 12:02:08.882","trace":"[{/go/src/github.com/giantswarm/cert-operator/vendor/github.com/giantswarm/microkit/server/server.go:465: } {/go/src/github.com/giantswarm/cert-operator/vendor/github.com/giantswarm/microendpoint/endpoint/healthz/endpoint.go:78: expected 'healthz.Responses' got '[]healthz.Response'} {wrong type}]"}
{"caller":"github.com/giantswarm/cert-operator/vendor/github.com/giantswarm/microkit/server/server.go:253","code":"500","endpoint":"healthz","method":"get","path":"/healthz","time":"17-08-07 12:02:08.882"}
```