### PR TITLE
Adds vault error metrics

### DIFF
--- a/service/healthz/vault/metrics.go
+++ b/service/healthz/vault/metrics.go
@@ -1,0 +1,44 @@
+package vault
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	prometheusNamespace = "microendpoint"
+	prometheusSubsystem = "vault"
+)
+
+var (
+	vaultPermissionDenied = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: prometheusNamespace,
+		Subsystem: prometheusSubsystem,
+		Name:      "permission_denied",
+		Help:      "Binary gauge for vault permission denied error.",
+	})
+
+	vaultUnknownError = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: prometheusNamespace,
+		Subsystem: prometheusSubsystem,
+		Name:      "unknown_error",
+		Help:      "Binary gauge for vault unknown error.",
+	})
+)
+
+func init() {
+	prometheus.MustRegister(vaultPermissionDenied)
+	prometheus.MustRegister(vaultUnknownError)
+}
+
+func setVaultPermissionDenied() {
+	vaultPermissionDenied.Set(1)
+}
+
+func setVaultUnknownError() {
+	vaultUnknownError.Set(1)
+}
+
+func setVaultOK() {
+	vaultPermissionDenied.Set(0)
+	vaultUnknownError.Set(0)
+}

--- a/service/healthz/vault/service.go
+++ b/service/healthz/vault/service.go
@@ -3,6 +3,7 @@ package vault
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/giantswarm/microerror"
@@ -98,9 +99,17 @@ func (s *Service) GetHealthz(ctx context.Context) (healthz.Response, error) {
 		go func() {
 			_, err := s.vaultClient.Sys().ListMounts()
 			if err != nil {
+				if strings.Contains(err.Error(), "permission denied") {
+					setVaultPermissionDenied()
+				} else {
+					setVaultUnknownError()
+				}
+
 				ch <- err.Error()
 				return
 			}
+
+			setVaultOK()
 			ch <- ""
 		}()
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1784

This adds two new metrics: `microendpoint_vault_permission_denied` and `microendpoint_vault_unknown_error`.

The value of these metrics are 0 if everything is okay.

When we perform a health check, if a permission denied error is returned, the value of `microendpoint_vault_permission_denied` will be set to 1. If any other kind of error is returned, `microendpoint_vault_unknown_error` will be set to 1. A successful health check sets the value of both metrics to 0.

The following examples use `cert-operator`, with this PR vendored.

e.g: everything okay:
```
$ curl localhost:8002/healthz
[{"description":"Ensure Kubernetes API availability.","failed":false,"message":"all good","name":"k8s"},{"description":"Ensure Vault API availability.","failed":false,"message":"all good","name":"vault"}]
```
```
# HELP microendpoint_vault_permission_denied Binary gauge for vault permission denied error.
# TYPE microendpoint_vault_permission_denied gauge
microendpoint_vault_permission_denied 0
# HELP microendpoint_vault_unknown_error Binary gauge for vault unknown error.
# TYPE microendpoint_vault_unknown_error gauge
microendpoint_vault_unknown_error 0
```

e.g: vault token incorrect / expired:
```
$ curl localhost:8002/healthz
[{"description":"Ensure Kubernetes API availability.","failed":false,"message":"all good","name":"k8s"},{"description":"Ensure Vault API availability.","failed":true,"message":"Error making API request.\n\nURL: GET http://127.0.0.1:9000/v1/sys/mounts\nCode: 400. Errors:\n\n* permission denied","name":"vault"}]
```
```
# HELP microendpoint_vault_permission_denied Binary gauge for vault permission denied error.
# TYPE microendpoint_vault_permission_denied gauge
microendpoint_vault_permission_denied 1
# HELP microendpoint_vault_unknown_error Binary gauge for vault unknown error.
# TYPE microendpoint_vault_unknown_error gauge
microendpoint_vault_unknown_error 0
```

e.g: vault unavailable:
```
$ curl localhost:8002/healthz
[{"description":"Ensure Kubernetes API availability.","failed":false,"message":"all good","name":"k8s"},{"description":"Ensure Vault API availability.","failed":true,"message":"Get http://127.0.0.1:9000/v1/sys/mounts: dial tcp 127.0.0.1:9000: getsockopt: connection refused","name":"vault"}]
```
```
# HELP microendpoint_vault_permission_denied Binary gauge for vault permission denied error.
# TYPE microendpoint_vault_permission_denied gauge
microendpoint_vault_permission_denied 0
# HELP microendpoint_vault_unknown_error Binary gauge for vault unknown error.
# TYPE microendpoint_vault_unknown_error gauge
microendpoint_vault_unknown_error 1
```

Follow up PRs will be vendoring this into microkit, and then vendoring microkit into cluster-service and cert-operator. Also, adding new alerts for these metrics being 1.