### PR TITLE
exposes last bundle version

### DIFF
--- a/service/version/metric.go
+++ b/service/version/metric.go
@@ -20,6 +20,7 @@ func init() {
 }
 
 func (s *Service) updateBuildInfoMetric() {
-	buildInfo.WithLabelValues(s.versionBundles[0].Version, s.gitCommit, runtime.Version(), runtime.GOOS, runtime.GOARCH).Set(1)
-	buildInfo.WithLabelValues("test", s.gitCommit, runtime.Version(), runtime.GOOS, runtime.GOARCH).Set(1)
+	for _, bundle := range s.versionBundles {
+		buildInfo.WithLabelValues(bundle.Version, s.gitCommit, runtime.Version(), runtime.GOOS, runtime.GOARCH).Set(1)
+	}
 }

--- a/service/version/metric.go
+++ b/service/version/metric.go
@@ -12,7 +12,7 @@ var buildInfo = prometheus.NewGaugeVec(
 		Name:      "build_info",
 		Help:      "A metric with a constant '1' value labeled by commit, golang version, golang os, and golang arch.",
 	},
-	[]string{"commit", "golang_version", "golang_goos", "golang_goarch"},
+	[]string{"bundle_version", "commit", "golang_version", "golang_goos", "golang_goarch"},
 )
 
 func init() {
@@ -20,5 +20,5 @@ func init() {
 }
 
 func (s *Service) updateBuildInfoMetric() {
-	buildInfo.WithLabelValues(s.gitCommit, runtime.Version(), runtime.GOOS, runtime.GOARCH).Set(1)
+	buildInfo.WithLabelValues(s.versionBundles[0].Version, s.gitCommit, runtime.Version(), runtime.GOOS, runtime.GOARCH).Set(1)
 }

--- a/service/version/metric.go
+++ b/service/version/metric.go
@@ -12,7 +12,7 @@ var buildInfo = prometheus.NewGaugeVec(
 		Name:      "build_info",
 		Help:      "A metric with a constant '1' value labeled by commit, golang version, golang os, and golang arch.",
 	},
-	[]string{"bundle_version", "commit", "golang_version", "golang_goos", "golang_goarch"},
+	[]string{"commit", "golang_version", "golang_goos", "golang_goarch", "version"},
 )
 
 func init() {
@@ -21,6 +21,6 @@ func init() {
 
 func (s *Service) updateBuildInfoMetric() {
 	for _, bundle := range s.versionBundles {
-		buildInfo.WithLabelValues(bundle.Version, s.gitCommit, runtime.Version(), runtime.GOOS, runtime.GOARCH).Set(1)
+		buildInfo.WithLabelValues(s.gitCommit, runtime.Version(), runtime.GOOS, runtime.GOARCH, bundle.Version).Set(1)
 	}
 }

--- a/service/version/metric.go
+++ b/service/version/metric.go
@@ -15,9 +15,11 @@ var buildInfo = prometheus.NewGaugeVec(
 	[]string{"bundle_version", "commit", "golang_version", "golang_goos", "golang_goarch"},
 )
 
+func init() {
+	prometheus.MustRegister(buildInfo)
+}
+
 func (s *Service) updateBuildInfoMetric() {
-	prometheus.MustRegister(buildInfo)
 	buildInfo.WithLabelValues(s.versionBundles[0].Version, s.gitCommit, runtime.Version(), runtime.GOOS, runtime.GOARCH).Set(1)
-	prometheus.MustRegister(buildInfo)
 	buildInfo.WithLabelValues("test", s.gitCommit, runtime.Version(), runtime.GOOS, runtime.GOARCH).Set(1)
 }

--- a/service/version/metric.go
+++ b/service/version/metric.go
@@ -15,11 +15,9 @@ var buildInfo = prometheus.NewGaugeVec(
 	[]string{"bundle_version", "commit", "golang_version", "golang_goos", "golang_goarch"},
 )
 
-func init() {
-	prometheus.MustRegister(buildInfo)
-}
-
 func (s *Service) updateBuildInfoMetric() {
+	prometheus.MustRegister(buildInfo)
 	buildInfo.WithLabelValues(s.versionBundles[0].Version, s.gitCommit, runtime.Version(), runtime.GOOS, runtime.GOARCH).Set(1)
+	prometheus.MustRegister(buildInfo)
 	buildInfo.WithLabelValues("test", s.gitCommit, runtime.Version(), runtime.GOOS, runtime.GOARCH).Set(1)
 }

--- a/service/version/metric.go
+++ b/service/version/metric.go
@@ -21,4 +21,5 @@ func init() {
 
 func (s *Service) updateBuildInfoMetric() {
 	buildInfo.WithLabelValues(s.versionBundles[0].Version, s.gitCommit, runtime.Version(), runtime.GOOS, runtime.GOARCH).Set(1)
+	buildInfo.WithLabelValues("test", s.gitCommit, runtime.Version(), runtime.GOOS, runtime.GOARCH).Set(1)
 }


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/7337

This PR exposes each bundle version the operator is reconciling to prometheus.

example from prometheus :
```
giantswarm_build_info{app="aws-operator-711b5819db6c0ca5ef7e6024169eaef18c",bundle_version="7.0.1-dev",cluster_id="ginger",cluster_type="host",commit="711b5819db6c0ca5ef7e6024169eaef18c902a29",golang_goarch="amd64",golang_goos="linux",golang_version="go1.13.1",instance="192.168.15.33:8000",job="host-cluster-ginger-workload",namespace="giantswarm"}
```