### PR TITLE
metrics: rename version > reconciled_version

### DIFF
--- a/service/version/metric.go
+++ b/service/version/metric.go
@@ -12,7 +12,7 @@ var buildInfo = prometheus.NewGaugeVec(
 		Name:      "build_info",
 		Help:      "A metric with a constant '1' value labeled by commit, golang version, golang os, and golang arch.",
 	},
-	[]string{"commit", "golang_version", "golang_goos", "golang_goarch", "version"},
+	[]string{"commit", "golang_version", "golang_goos", "golang_goarch", "reconciled_version"},
 )
 
 func init() {


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/7739

This PR align the name of the reconciled version label in `giantswarm_build_info` metric with the upcoming `giantswarm.io/reconciled-version` CR label, https://github.com/giantswarm/fmt/pull/81